### PR TITLE
Update install-octopi.sh

### DIFF
--- a/scripts/install-octopi.sh
+++ b/scripts/install-octopi.sh
@@ -34,9 +34,10 @@ create_virtualenv()
     report_status "Updating python virtual environment..."
 
     # Create virtualenv if it doesn't already exist
-    [ ! -d ${PYTHONDIR} ] && virtualenv ${PYTHONDIR}
+    [ ! -d ${PYTHONDIR} ] && virtualenv --no-setuptools ${PYTHONDIR}
 
     # Install/update dependencies
+    ${PYTHONDIR}/bin/pip install setuptools==44.0.0
     ${PYTHONDIR}/bin/pip install -r ${SRCDIR}/scripts/klippy-requirements.txt
 }
 


### PR DESCRIPTION
From https://github.com/pypa/setuptools/blob/master/CHANGES.rst

v45.0.0
    # 1458: Drop support for Python 2. Setuptools now requires Python 3.5 or later. Install setuptools using pip >=9 or pin to Setuptools <45 to maintain 2.7 support.

This fix pin to Setuptools 44.0.0.